### PR TITLE
Add Windows installer and cross-platform desktop recovery

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,11 @@ permissions:
 
 jobs:
   test:
-    runs-on: macos-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [macos-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
@@ -18,4 +22,5 @@ jobs:
           cache: npm
       - run: npm ci
       - run: npm test
-      - run: bash -n install.sh uninstall.sh
+      - if: runner.os == 'macOS'
+        run: bash -n install.sh uninstall.sh

--- a/README.md
+++ b/README.md
@@ -1,8 +1,28 @@
 # Codex Sidebar Enhancer
 
-一个面向 macOS Codex 桌面体验的本地侧栏增强工具。它为对话增加摘要、最近消息预览、双列卡片、项目标签搜索、最近使用排序和额度展示，同时不修改应用包或对话正文。
+一个面向 macOS 与 Windows Codex 桌面体验的本地侧栏增强工具。它为对话增加摘要、最近消息预览、双列卡片、项目标签搜索、最近使用排序和额度展示，同时不修改应用包或对话正文。
 
-## 一行安装
+## Windows 一行安装
+
+在 PowerShell 中粘贴并回车：
+
+```powershell
+irm https://raw.githubusercontent.com/yubowen123/codex-sidebar-enhancer/main/install.ps1 | iex
+```
+
+Windows 安装器会自动：
+
+1. 安装到 `%LOCALAPPDATA%\Codex Sidebar Enhancer`；
+2. 优先复用 Node.js 22+；本机缺少时，从 Node.js 官网下载对应架构的便携版 Node 22，并校验 SHA-256；
+3. 在当前用户的“启动”目录创建隐藏后台注入器快捷方式，登录后自动恢复；
+4. 在开始菜单创建 **Codex Sidebar Enhancer** 启动器；
+5. 用本地回环调试端口启动 Codex/ChatGPT。首次启用时，如果应用正在运行，会先询问是否重启一次。
+
+以后可照常打开 Codex/ChatGPT；后台注入器发现普通启动没有增强端口时，会自动纠正启动方式。无需管理员权限。
+
+> 不想直接执行远程脚本？先[查看 install.ps1](./install.ps1)，或下载仓库后在 PowerShell 运行 `.\install.ps1`。
+
+## macOS 一行安装
 
 在“终端”中粘贴并回车：
 
@@ -24,11 +44,19 @@
 
 ## 一行卸载
 
+Windows PowerShell：
+
+```powershell
+irm https://raw.githubusercontent.com/yubowen123/codex-sidebar-enhancer/main/uninstall.ps1 | iex
+```
+
+macOS 终端：
+
 ```bash
 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/yubowen123/codex-sidebar-enhancer/main/uninstall.sh)"
 ```
 
-卸载会停止增强进程，并移除安装目录、用户级 LaunchAgent、启动器和增强日志，不会删除 Codex 对话或设置。
+卸载会停止增强进程，并移除本工具的安装目录、当前用户自启动项、启动器和增强日志，不会删除 Codex 对话或设置。
 
 ## 功能
 
@@ -53,10 +81,10 @@
 
 ## 系统要求
 
-- macOS 13 或更新版本；
-- 已安装 Codex 或包含 Codex 工作区的 ChatGPT 桌面应用；
+- macOS 13+，或 Windows 10/11；
+- 已安装当前 Codex 或包含 Codex 工作区的 ChatGPT 桌面应用；[OpenAI 官方桌面应用](https://openai.com/index/introducing-the-codex-app/)支持 macOS 与 Windows；
 - 本地存在 `~/.codex` 会话目录；
-- Node.js 22 或更新版本。安装器会优先复用系统 Node.js，没有时自动使用桌面应用内置 Node.js。
+- Node.js 22 或更新版本。macOS 安装器会复用系统或桌面应用内置 Node.js；Windows 缺少 Node 时会安装经过 SHA-256 校验的便携运行时到本工具目录。
 
 当前实现已在 Codex `26.803.41515` 对应界面结构上验证。Codex 大版本更新如果更改侧栏 DOM 锚点，可能需要同步升级本项目。
 
@@ -67,23 +95,30 @@
 - 不开启对外 HTTP 服务，不上传对话、额度或标签；
 - CDP 只使用回环地址 `127.0.0.1:9231`；
 - TV 只嵌入固定的 `https://dz-ailab.dzkjm.cn/canvas/projects?category=personal`，使用受限 iframe；仅在 TV 面板打开期间由本地宿主放行嵌入所需的内容安全策略，关闭或切换页面后立即恢复；
-- 安装内容完全位于当前用户目录，可通过卸载脚本完整移除。
+- 安装内容完全位于当前用户目录，可通过对应平台的卸载脚本完整移除；Windows 不创建管理员级服务或系统级注册表项。
 
 ## 更新与排查
 
 更新时重新运行安装命令即可。安装器会原子替换旧版本，并迁移早期 `com.yubowen.codex-conversation-preview` LaunchAgent。
 
-日志位置：
+macOS 日志位置：
 
 ```text
 ~/Library/Logs/CodexSidebarEnhancer/injector.log
 ~/Library/Logs/CodexSidebarEnhancer/injector.error.log
 ```
 
+Windows 日志位置：
+
+```text
+%LOCALAPPDATA%\CodexSidebarEnhancer\Logs\injector.log
+%LOCALAPPDATA%\CodexSidebarEnhancer\Logs\injector.error.log
+```
+
 如果增强没有出现：
 
 1. 等待约 10 秒，后台增强会自动纠正一次普通启动；
-2. 仍未出现时退出 Codex/ChatGPT，再打开 `~/Applications/Codex Sidebar Enhancer.app`；
+2. 仍未出现时退出 Codex/ChatGPT，再打开 macOS 的 `~/Applications/Codex Sidebar Enhancer.app`，或 Windows 开始菜单中的 **Codex Sidebar Enhancer**；
 3. 查看上述日志。
 
 ## 本地开发
@@ -96,10 +131,18 @@ npm test
 npm run inject
 ```
 
+Windows 本地安装测试：
+
+```powershell
+$env:CODEX_SIDEBAR_SOURCE_DIR = (Get-Location).Path
+.\install.ps1
+```
+
 实时界面验收脚本需要已用 `9231` 端口启动的 Codex：
 
 ```bash
 node scripts/verify-shortcut-grid.mjs
+node scripts/verify-shortcut-card-clicks.mjs
 node scripts/verify-shortcut-settings-click.mjs
 node scripts/verify-tv-panel.mjs
 node scripts/verify-section-tabs.mjs

--- a/inject/conversation-preview.user.js
+++ b/inject/conversation-preview.user.js
@@ -1937,13 +1937,10 @@
         const viewport = document.querySelector("[data-app-shell-main-content-layout]");
         if (!viewport) return null;
         const viewportRect = viewport.getBoundingClientRect();
-        const headerBottom = document.querySelector("main > header")?.getBoundingClientRect().bottom
-          ?? viewportRect.top;
         return Array.from(viewport.children).find((candidate) => {
           const rect = candidate.getBoundingClientRect();
           return rect.width >= viewportRect.width * 0.8
-            && rect.height >= viewportRect.height * 0.7
-            && rect.top >= headerBottom - 1;
+            && rect.height >= viewportRect.height * 0.7;
         }) || null;
       })();
     }
@@ -2215,12 +2212,10 @@
       const viewport = document.querySelector("[data-app-shell-main-content-layout]");
       if (viewport) {
         const viewportRect = viewport.getBoundingClientRect();
-        const headerBottom = document.querySelector("main > header")?.getBoundingClientRect().bottom ?? viewportRect.top;
         frameHost = Array.from(viewport.children).find((candidate) => {
           const rect = candidate.getBoundingClientRect();
           return rect.width >= viewportRect.width * 0.8
-            && rect.height >= viewportRect.height * 0.7
-            && rect.top >= headerBottom - 1;
+            && rect.height >= viewportRect.height * 0.7;
         }) || null;
       }
     }

--- a/install.ps1
+++ b/install.ps1
@@ -1,0 +1,162 @@
+[CmdletBinding()]
+param()
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+$ProgressPreference = "SilentlyContinue"
+
+function Get-Setting([string]$Name, [string]$DefaultValue) {
+  $value = [Environment]::GetEnvironmentVariable($Name)
+  if ([string]::IsNullOrWhiteSpace($value)) { return $DefaultValue }
+  return $value
+}
+
+function Test-Node22([string]$Candidate) {
+  if ([string]::IsNullOrWhiteSpace($Candidate) -or -not (Test-Path -LiteralPath $Candidate -PathType Leaf)) {
+    return $false
+  }
+  try {
+    $major = & $Candidate -p "Number(process.versions.node.split('.')[0])"
+    return ($LASTEXITCODE -eq 0 -and [int]$major -ge 22)
+  } catch {
+    return $false
+  }
+}
+
+function Copy-Package([string]$From, [string]$To) {
+  $entries = @(
+    "LICENSE", "README.md", "package.json", "package-lock.json",
+    "inject", "lib", "scripts", "windows", "install.ps1", "uninstall.ps1"
+  )
+  foreach ($entry in $entries) {
+    $source = Join-Path $From $entry
+    if (Test-Path -LiteralPath $source) {
+      Copy-Item -LiteralPath $source -Destination $To -Recurse -Force
+    }
+  }
+}
+
+function Install-PortableNode([string]$Destination, [string]$Scratch) {
+  $architecture = [System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture.ToString()
+  if ($architecture -eq "Arm64") { $platform = "win-arm64" }
+  elseif ($architecture -eq "X64") { $platform = "win-x64" }
+  else { throw "Windows architecture $architecture is not supported." }
+
+  $baseUrl = "https://nodejs.org/dist/latest-v22.x"
+  $checksumsPath = Join-Path $Scratch "SHASUMS256.txt"
+  Invoke-WebRequest -UseBasicParsing -Uri "$baseUrl/SHASUMS256.txt" -OutFile $checksumsPath
+  $checksums = Get-Content -LiteralPath $checksumsPath
+  $line = $checksums | Where-Object { $_ -match "^([a-fA-F0-9]{64})\s+(node-v.+-$platform\.zip)$" } | Select-Object -First 1
+  if (-not $line) { throw "A verified Node.js 22 archive for $platform was not found." }
+  $null = $line -match "^([a-fA-F0-9]{64})\s+(.+)$"
+  $expectedHash = $Matches[1].ToUpperInvariant()
+  $fileName = $Matches[2]
+  $archivePath = Join-Path $Scratch $fileName
+  Invoke-WebRequest -UseBasicParsing -Uri "$baseUrl/$fileName" -OutFile $archivePath
+  $actualHash = (Get-FileHash -LiteralPath $archivePath -Algorithm SHA256).Hash.ToUpperInvariant()
+  if ($actualHash -ne $expectedHash) { throw "Node.js archive checksum verification failed." }
+
+  $expanded = Join-Path $Scratch "node-expanded"
+  Expand-Archive -LiteralPath $archivePath -DestinationPath $expanded -Force
+  $runtimeSource = Get-ChildItem -LiteralPath $expanded -Directory | Select-Object -First 1
+  if (-not $runtimeSource -or -not (Test-Path -LiteralPath (Join-Path $runtimeSource.FullName "node.exe"))) {
+    throw "The downloaded Node.js runtime is incomplete."
+  }
+  Copy-Item -LiteralPath $runtimeSource.FullName -Destination $Destination -Recurse -Force
+}
+
+function New-Shortcut([string]$Path, [string]$Target, [string]$Arguments, [string]$WorkingDirectory) {
+  $shell = New-Object -ComObject WScript.Shell
+  $shortcut = $shell.CreateShortcut($Path)
+  $shortcut.TargetPath = $Target
+  $shortcut.Arguments = $Arguments
+  $shortcut.WorkingDirectory = $WorkingDirectory
+  $shortcut.IconLocation = "$Target,0"
+  $shortcut.Save()
+}
+
+$repository = Get-Setting "CODEX_SIDEBAR_REPOSITORY" "yubowen123/codex-sidebar-enhancer"
+$repositoryRef = Get-Setting "CODEX_SIDEBAR_REF" "main"
+$localAppData = [Environment]::GetFolderPath("LocalApplicationData")
+$installDir = Get-Setting "CODEX_SIDEBAR_INSTALL_DIR" (Join-Path $localAppData "Codex Sidebar Enhancer")
+$logsDir = Get-Setting "CODEX_SIDEBAR_LOGS_DIR" (Join-Path $localAppData "CodexSidebarEnhancer\Logs")
+$startupDir = Get-Setting "CODEX_SIDEBAR_STARTUP_DIR" ([Environment]::GetFolderPath("Startup"))
+$startMenuDir = Get-Setting "CODEX_SIDEBAR_START_MENU_DIR" (Join-Path ([Environment]::GetFolderPath("Programs")) "Codex Sidebar Enhancer")
+$sourceDir = Get-Setting "CODEX_SIDEBAR_SOURCE_DIR" ""
+$port = [int](Get-Setting "CODEX_SIDEBAR_PORT" "9231")
+if ($port -lt 1 -or $port -gt 65535) { throw "Invalid debugging port: $port" }
+
+$fullInstallDir = [IO.Path]::GetFullPath($installDir)
+$root = [IO.Path]::GetPathRoot($fullInstallDir)
+if ($fullInstallDir -eq $root -or $fullInstallDir -eq [IO.Path]::GetFullPath($localAppData)) {
+  throw "Unsafe install directory: $fullInstallDir"
+}
+
+$scratch = Join-Path ([IO.Path]::GetTempPath()) ("codex-sidebar-" + [guid]::NewGuid().ToString("N"))
+$stagingDir = Join-Path ([IO.Path]::GetDirectoryName($fullInstallDir)) (".codex-sidebar-new-" + [guid]::NewGuid().ToString("N"))
+$backupDir = Join-Path ([IO.Path]::GetDirectoryName($fullInstallDir)) (".codex-sidebar-old-" + [guid]::NewGuid().ToString("N"))
+$installed = $false
+
+try {
+  New-Item -ItemType Directory -Path $scratch -Force | Out-Null
+  if ([string]::IsNullOrWhiteSpace($sourceDir)) {
+    $archive = Join-Path $scratch "source.zip"
+    Invoke-WebRequest -UseBasicParsing -Uri "https://github.com/$repository/archive/refs/heads/$repositoryRef.zip" -OutFile $archive
+    $expandedSource = Join-Path $scratch "source"
+    Expand-Archive -LiteralPath $archive -DestinationPath $expandedSource -Force
+    $sourceDir = (Get-ChildItem -LiteralPath $expandedSource -Directory | Select-Object -First 1).FullName
+  }
+  if (-not (Test-Path -LiteralPath (Join-Path $sourceDir "scripts\injector.mjs"))) {
+    throw "Downloaded package is incomplete."
+  }
+
+  New-Item -ItemType Directory -Path ([IO.Path]::GetDirectoryName($fullInstallDir)) -Force | Out-Null
+  New-Item -ItemType Directory -Path $stagingDir -Force | Out-Null
+  Copy-Package $sourceDir $stagingDir
+
+  $nodePath = Get-Setting "CODEX_SIDEBAR_NODE" ""
+  if (-not (Test-Node22 $nodePath)) {
+    $nodeCommand = Get-Command node.exe -ErrorAction SilentlyContinue
+    if ($nodeCommand -and (Test-Node22 $nodeCommand.Source)) { $nodePath = $nodeCommand.Source }
+  }
+  if (-not (Test-Node22 $nodePath)) {
+    $runtimeStaging = Join-Path $stagingDir "runtime"
+    Install-PortableNode $runtimeStaging $scratch
+    $nodePath = Join-Path $fullInstallDir "runtime\node.exe"
+  }
+
+  New-Item -ItemType Directory -Path (Join-Path $stagingDir "windows") -Force | Out-Null
+  $config = @{ nodePath = $nodePath; port = $port; logsDir = $logsDir } | ConvertTo-Json
+  $utf8 = New-Object System.Text.UTF8Encoding($false)
+  [IO.File]::WriteAllText((Join-Path $stagingDir "windows\config.json"), $config, $utf8)
+
+  if (Test-Path -LiteralPath $fullInstallDir) { Move-Item -LiteralPath $fullInstallDir -Destination $backupDir }
+  Move-Item -LiteralPath $stagingDir -Destination $fullInstallDir
+  $installed = $true
+
+  New-Item -ItemType Directory -Path $logsDir -Force | Out-Null
+  New-Item -ItemType Directory -Path $startupDir -Force | Out-Null
+  New-Item -ItemType Directory -Path $startMenuDir -Force | Out-Null
+  $powerShellPath = (Get-Process -Id $PID).Path
+  $launcherPath = Join-Path $fullInstallDir "windows\launcher.ps1"
+  $commonArgs = "-NoProfile -ExecutionPolicy Bypass -WindowStyle Hidden -File `"$launcherPath`""
+  New-Shortcut (Join-Path $startupDir "Codex Sidebar Enhancer.lnk") $powerShellPath "$commonArgs -InjectorOnly" $fullInstallDir
+  New-Shortcut (Join-Path $startMenuDir "Codex Sidebar Enhancer.lnk") $powerShellPath $commonArgs $fullInstallDir
+
+  if (Test-Path -LiteralPath $backupDir) { Remove-Item -LiteralPath $backupDir -Recurse -Force }
+  if ((Get-Setting "CODEX_SIDEBAR_SKIP_OPEN" "0") -ne "1") {
+    & $powerShellPath -NoProfile -ExecutionPolicy Bypass -WindowStyle Hidden -File $launcherPath
+  }
+  Write-Output "Codex Sidebar Enhancer installed for Windows."
+  Write-Output "Launcher: $startMenuDir"
+  Write-Output "Logs: $logsDir"
+} catch {
+  if ($installed -and (Test-Path -LiteralPath $fullInstallDir)) {
+    Remove-Item -LiteralPath $fullInstallDir -Recurse -Force
+  }
+  if (Test-Path -LiteralPath $backupDir) { Move-Item -LiteralPath $backupDir -Destination $fullInstallDir }
+  throw
+} finally {
+  if (Test-Path -LiteralPath $stagingDir) { Remove-Item -LiteralPath $stagingDir -Recurse -Force }
+  if (Test-Path -LiteralPath $scratch) { Remove-Item -LiteralPath $scratch -Recurse -Force }
+}

--- a/lib/desktop-runtime.mjs
+++ b/lib/desktop-runtime.mjs
@@ -1,0 +1,64 @@
+import { execFile, spawn } from "node:child_process";
+import { promisify } from "node:util";
+
+import {
+  desktopAppLaunchArgs,
+  parseDesktopAppProcess,
+  parseWindowsDesktopAppProcess,
+  windowsDesktopAppLaunchArgs,
+} from "./injector-state.mjs";
+
+const defaultExecFileAsync = promisify(execFile);
+
+const WINDOWS_PROCESS_QUERY = [
+  "$items = Get-CimInstance Win32_Process",
+  "| Where-Object { $_.Name -in @('ChatGPT.exe','Codex.exe') -and $_.CommandLine -notmatch '(?:^|\\s)--type=' }",
+  "| Select-Object ProcessId,Name,ExecutablePath,CommandLine;",
+  "@($items) | ConvertTo-Json -Compress",
+].join(" ");
+
+export function createDesktopAppRuntime({
+  platform = process.platform,
+  execFileAsync = defaultExecFileAsync,
+  spawnProcess = spawn,
+} = {}) {
+  return {
+    async readProcess() {
+      if (platform === "darwin") {
+        const { stdout } = await execFileAsync("/bin/ps", ["-axo", "pid=,command="]);
+        return parseDesktopAppProcess(stdout);
+      }
+      if (platform === "win32") {
+        const { stdout } = await execFileAsync("powershell.exe", [
+          "-NoProfile",
+          "-NonInteractive",
+          "-Command",
+          WINDOWS_PROCESS_QUERY,
+        ]);
+        return parseWindowsDesktopAppProcess(stdout);
+      }
+      return null;
+    },
+
+    async quit(app) {
+      if (platform === "darwin") {
+        await execFileAsync("/usr/bin/osascript", [
+          "-e",
+          `tell application id ${JSON.stringify(app.bundleId)} to quit`,
+        ]);
+      } else if (platform === "win32") {
+        await execFileAsync("taskkill.exe", ["/PID", String(app.pid), "/T"]);
+      }
+    },
+
+    launch(appPath, port) {
+      const command = platform === "darwin" ? "/usr/bin/open" : appPath;
+      const args = platform === "darwin"
+        ? desktopAppLaunchArgs(appPath, port)
+        : windowsDesktopAppLaunchArgs(port);
+      const child = spawnProcess(command, args, { detached: true, stdio: "ignore" });
+      child.unref();
+      return child;
+    },
+  };
+}

--- a/lib/injector-state.mjs
+++ b/lib/injector-state.mjs
@@ -42,6 +42,35 @@ export function desktopAppLaunchArgs(appPath, port) {
   ];
 }
 
+export function windowsDesktopAppLaunchArgs(port) {
+  return [
+    `--remote-debugging-port=${port}`,
+    `--remote-allow-origins=http://127.0.0.1:${port}`,
+    "--enable-features=LocalNetworkAccessForSubframeNavigationsWarningOnly",
+  ];
+}
+
+export function parseWindowsDesktopAppProcess(processList) {
+  let items;
+  try {
+    const parsed = JSON.parse(String(processList || "[]"));
+    items = Array.isArray(parsed) ? parsed : parsed ? [parsed] : [];
+  } catch {
+    return null;
+  }
+  for (const item of items) {
+    const name = String(item?.Name || "");
+    const executablePath = String(item?.ExecutablePath || "");
+    const commandLine = String(item?.CommandLine || "");
+    if (!/^(?:ChatGPT|Codex)\.exe$/i.test(name)) continue;
+    if (!executablePath || /(?:^|\s)--type=/i.test(commandLine)) continue;
+    const pid = Number(item?.ProcessId);
+    if (!Number.isInteger(pid) || pid < 1) continue;
+    return { pid, appPath: executablePath, appName: name };
+  }
+  return null;
+}
+
 export class DesktopAppRecovery {
   constructor({ quitRetryMs = 5_000 } = {}) {
     this.quitRetryMs = quitRetryMs;

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "codex-sidebar-enhancer",
   "version": "1.0.0",
-  "description": "A local, reversible sidebar enhancement for the Codex desktop experience on macOS.",
+  "description": "A local, reversible sidebar enhancement for the Codex desktop experience on macOS and Windows.",
   "license": "MIT",
   "homepage": "https://github.com/yubowen123/codex-sidebar-enhancer#readme",
   "repository": {
@@ -12,6 +12,7 @@
     "codex",
     "sidebar",
     "macos",
+    "windows",
     "productivity"
   ],
   "engines": {
@@ -22,7 +23,7 @@
     "inspect": "node scripts/inspect-sidebar.mjs",
     "test": "node --test",
     "inject": "node scripts/injector.mjs --port 9231 --watch",
-    "verify:install": "node --test test/install-config.test.mjs test/public-install.test.mjs"
+    "verify:install": "node --test test/install-config.test.mjs test/public-install.test.mjs test/windows-public-install.test.mjs"
   },
   "devDependencies": {
     "ws": "^8.21.3"

--- a/scripts/injector.mjs
+++ b/scripts/injector.mjs
@@ -1,10 +1,8 @@
 #!/usr/bin/env node
 
 import { readFile } from "node:fs/promises";
-import { execFile, spawn } from "node:child_process";
 import { randomUUID } from "node:crypto";
 import path from "node:path";
-import { promisify } from "node:util";
 import { fileURLToPath } from "node:url";
 
 import { connectMainCodex, readTargets, selectMainCodexTarget } from "./cdp-client.mjs";
@@ -13,10 +11,9 @@ import { presentCardPreview } from "../lib/card-view.mjs";
 import { presentRateLimit } from "../lib/usage-data.mjs";
 import {
   DesktopAppRecovery,
-  desktopAppLaunchArgs,
   needsPreviewAttachment,
-  parseDesktopAppProcess,
 } from "../lib/injector-state.mjs";
+import { createDesktopAppRuntime } from "../lib/desktop-runtime.mjs";
 import { buildHomeProjectShelf, readTaskboardSnapshot } from "../lib/home-projects.mjs";
 
 const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
@@ -25,7 +22,6 @@ const SCRIPT_ID_GLOBAL = "__CODEX_CONVERSATION_PREVIEW_SCRIPT_IDENTIFIER__";
 const TV_HOST_BINDING_NAME = "__codexTvHostV1";
 const TV_HOST_TOKEN_GLOBAL = "__CODEX_TV_HOST_TOKEN__";
 const TV_URL = "https://dz-ailab.dzkjm.cn/canvas/projects?category=personal";
-const execFileAsync = promisify(execFile);
 
 function parseArgs(argv) {
   const options = { port: 9231, watch: false };
@@ -58,6 +54,7 @@ let tvHostToken = null;
 let tvHostUnsubscribers = [];
 let tvHostOperations = Promise.resolve();
 const desktopAppRecovery = new DesktopAppRecovery();
+const desktopAppRuntime = createDesktopAppRuntime();
 
 async function disableTvCsp(targetClient = client) {
   try { await targetClient?.send("Page.setBypassCSP", { enabled: false }); } catch {}
@@ -127,25 +124,15 @@ async function attach() {
   const nextTargetId = await targetId(options.port);
   if (!nextTargetId && options.watch) {
     let app = null;
-    try {
-      const { stdout } = await execFileAsync("/bin/ps", ["-axo", "pid=,command="]);
-      app = parseDesktopAppProcess(stdout);
-    } catch {}
+    try { app = await desktopAppRuntime.readProcess(); } catch {}
     const action = desktopAppRecovery.next({ targetAvailable: false, app });
     if (action?.type === "quit") {
       try {
-        await execFileAsync("/usr/bin/osascript", [
-          "-e",
-          `tell application id ${JSON.stringify(action.app.bundleId)} to quit`,
-        ]);
+        await desktopAppRuntime.quit(action.app);
         process.stdout.write(`Restarting ${action.app.appPath} to enable sidebar enhancement\n`);
       } catch {}
     } else if (action?.type === "launch") {
-      const child = spawn("/usr/bin/open", desktopAppLaunchArgs(action.appPath, options.port), {
-        detached: true,
-        stdio: "ignore",
-      });
-      child.unref();
+      desktopAppRuntime.launch(action.appPath, options.port);
       desktopAppRecovery.markLaunched();
       process.stdout.write(`Launching ${action.appPath} with sidebar enhancement enabled\n`);
     }

--- a/scripts/verify-shortcut-card-clicks.mjs
+++ b/scripts/verify-shortcut-card-clicks.mjs
@@ -1,0 +1,93 @@
+#!/usr/bin/env node
+
+import assert from "node:assert/strict";
+
+import { connectMainCodex } from "./cdp-client.mjs";
+
+async function waitFor(client, expression, message, timeoutMs = 5_000) {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (await client.evaluate(expression)) return;
+    await new Promise((resolve) => setTimeout(resolve, 50));
+  }
+  throw new Error(message);
+}
+
+async function inspectAndClick(client, name) {
+  const hit = await client.evaluate(`(() => {
+    const button = document.querySelector('#codex-sidebar-shortcut-grid [data-codex-sidebar-shortcut-name=${JSON.stringify(name)}]');
+    if (!button) return null;
+    window.__codexShortcutClickProbe = { button, events: [] };
+    for (const type of ['pointerdown', 'mousedown', 'mouseup', 'click']) {
+      document.addEventListener(type, (event) => {
+        window.__codexShortcutClickProbe?.events.push({
+          type,
+          name: event.target?.closest?.('[data-codex-sidebar-shortcut-name]')?.dataset.codexSidebarShortcutName || null,
+        });
+      }, { capture: true, once: true });
+    }
+    const rect = button.getBoundingClientRect();
+    const x = rect.left + rect.width / 2;
+    const y = rect.top + rect.height / 2;
+    const target = document.elementFromPoint(x, y);
+    return {
+      x,
+      y,
+      buttonTag: button.tagName,
+      buttonPointerEvents: getComputedStyle(button).pointerEvents,
+      hitTag: target?.tagName || null,
+      hitName: target?.closest?.('[data-codex-sidebar-shortcut-name]')?.dataset.codexSidebarShortcutName || null,
+      hitClass: target?.className || null,
+      hitAria: target?.closest?.('[aria-label]')?.getAttribute('aria-label') || null,
+    };
+  })()`);
+  assert.ok(hit, `${name} shortcut must exist`);
+  await client.send("Input.dispatchMouseEvent", { type: "mouseMoved", x: hit.x, y: hit.y });
+  await new Promise((resolve) => setTimeout(resolve, 120));
+  await client.send("Input.dispatchMouseEvent", { type: "mousePressed", x: hit.x, y: hit.y, button: "left", clickCount: 1 });
+  await new Promise((resolve) => setTimeout(resolve, 20));
+  await client.send("Input.dispatchMouseEvent", { type: "mouseReleased", x: hit.x, y: hit.y, button: "left", clickCount: 1 });
+  await new Promise((resolve) => setTimeout(resolve, 20));
+  const after = await client.evaluate(`(() => {
+    const probe = window.__codexShortcutClickProbe;
+    const current = document.querySelector('#codex-sidebar-shortcut-grid [data-codex-sidebar-shortcut-name=${JSON.stringify(name)}]');
+    return {
+      sameButton: probe?.button === current,
+      originalConnected: Boolean(probe?.button?.isConnected),
+      events: probe?.events || [],
+      currentHitName: document.elementFromPoint(${hit.x}, ${hit.y})
+        ?.closest?.('[data-codex-sidebar-shortcut-name]')?.dataset.codexSidebarShortcutName || null,
+    };
+  })()`);
+  return { ...hit, ...after };
+}
+
+const client = await connectMainCodex(9231);
+try {
+  await client.evaluate(`(() => {
+    window.__codexConversationPreviewInjection__?.closeTv?.(false);
+    window.__codexTaskboardInjection__?.close?.(false);
+  })()`);
+  await new Promise((resolve) => setTimeout(resolve, 600));
+
+  const tv = await inspectAndClick(client, "TV");
+  await waitFor(
+    client,
+    `document.documentElement.getAttribute("data-codex-tv-open") === "true"`,
+    `real TV click hit ${JSON.stringify(tv)} but did not open TV`,
+  );
+  await client.evaluate(`window.__codexConversationPreviewInjection__?.closeTv?.(false)`);
+
+  const projectManagement = await inspectAndClick(client, "项目管理");
+  await waitFor(
+    client,
+    `document.documentElement.getAttribute("data-codex-taskboard-open") === "true"`,
+    `real project-management click hit ${JSON.stringify(projectManagement)} but did not open Taskboard`,
+  );
+
+  process.stdout.write(`${JSON.stringify({ tv, projectManagement }, null, 2)}\n`);
+} finally {
+  try { await client.evaluate(`window.__codexConversationPreviewInjection__?.closeTv?.(false)`); } catch {}
+  try { await client.evaluate(`window.__codexTaskboardInjection__?.close?.(false)`); } catch {}
+  client.close();
+}

--- a/test/desktop-runtime.test.mjs
+++ b/test/desktop-runtime.test.mjs
@@ -1,0 +1,83 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { createDesktopAppRuntime } from "../lib/desktop-runtime.mjs";
+
+test("Windows runtime reads only the main desktop process and stops it by pid", async () => {
+  const calls = [];
+  const processList = JSON.stringify({
+    ProcessId: 700,
+    Name: "Codex.exe",
+    ExecutablePath: "C:\\Apps\\Codex.exe",
+    CommandLine: '"C:\\Apps\\Codex.exe"',
+  });
+  const runtime = createDesktopAppRuntime({
+    platform: "win32",
+    execFileAsync: async (command, args) => {
+      calls.push({ command, args });
+      if (command === "powershell.exe") return { stdout: processList };
+      return { stdout: "" };
+    },
+    spawnProcess: () => { throw new Error("not used"); },
+  });
+
+  assert.deepEqual(await runtime.readProcess(), {
+    pid: 700,
+    appPath: "C:\\Apps\\Codex.exe",
+    appName: "Codex.exe",
+  });
+  await runtime.quit({ pid: 700 });
+  assert.equal(calls[0].command, "powershell.exe");
+  assert.deepEqual(calls[1], { command: "taskkill.exe", args: ["/PID", "700", "/T"] });
+});
+
+test("Windows runtime launches the discovered executable detached with debugging enabled", () => {
+  const calls = [];
+  const child = { unrefCalled: false, unref() { this.unrefCalled = true; } };
+  const runtime = createDesktopAppRuntime({
+    platform: "win32",
+    execFileAsync: async () => ({ stdout: "" }),
+    spawnProcess(command, args, options) {
+      calls.push({ command, args, options });
+      return child;
+    },
+  });
+
+  runtime.launch("C:\\Apps\\ChatGPT.exe", 9231);
+  assert.deepEqual(calls, [{
+    command: "C:\\Apps\\ChatGPT.exe",
+    args: [
+      "--remote-debugging-port=9231",
+      "--remote-allow-origins=http://127.0.0.1:9231",
+      "--enable-features=LocalNetworkAccessForSubframeNavigationsWarningOnly",
+    ],
+    options: { detached: true, stdio: "ignore" },
+  }]);
+  assert.equal(child.unrefCalled, true);
+});
+
+test("macOS runtime keeps the existing exact process, quit, and open behavior", async () => {
+  const calls = [];
+  const child = { unref() {} };
+  const runtime = createDesktopAppRuntime({
+    platform: "darwin",
+    execFileAsync: async (command, args) => {
+      calls.push({ command, args });
+      if (command === "/bin/ps") {
+        return { stdout: "99 /Applications/ChatGPT.app/Contents/MacOS/ChatGPT\n" };
+      }
+      return { stdout: "" };
+    },
+    spawnProcess(command, args, options) {
+      calls.push({ command, args, options });
+      return child;
+    },
+  });
+
+  const app = await runtime.readProcess();
+  await runtime.quit(app);
+  runtime.launch(app.appPath, 9231);
+  assert.equal(calls[0].command, "/bin/ps");
+  assert.equal(calls[1].command, "/usr/bin/osascript");
+  assert.equal(calls[2].command, "/usr/bin/open");
+});

--- a/test/injector-state.test.mjs
+++ b/test/injector-state.test.mjs
@@ -99,3 +99,41 @@ test("desktop app recovery launches the app with the complete debugging argument
     "--enable-features=LocalNetworkAccessForSubframeNavigationsWarningOnly",
   ]);
 });
+
+test("Windows desktop app recovery ignores Electron helpers and selects the main process", async () => {
+  const state = await import("../lib/injector-state.mjs");
+  assert.equal(typeof state.parseWindowsDesktopAppProcess, "function");
+  const processList = JSON.stringify([
+    {
+      ProcessId: 401,
+      Name: "ChatGPT.exe",
+      ExecutablePath: "C:\\Program Files\\WindowsApps\\OpenAI.ChatGPT\\ChatGPT.exe",
+      CommandLine: '"C:\\Program Files\\WindowsApps\\OpenAI.ChatGPT\\ChatGPT.exe" --type=renderer',
+    },
+    {
+      ProcessId: 400,
+      Name: "ChatGPT.exe",
+      ExecutablePath: "C:\\Program Files\\WindowsApps\\OpenAI.ChatGPT\\ChatGPT.exe",
+      CommandLine: '"C:\\Program Files\\WindowsApps\\OpenAI.ChatGPT\\ChatGPT.exe"',
+    },
+  ]);
+
+  assert.deepEqual(state.parseWindowsDesktopAppProcess(processList), {
+    pid: 400,
+    appPath: "C:\\Program Files\\WindowsApps\\OpenAI.ChatGPT\\ChatGPT.exe",
+    appName: "ChatGPT.exe",
+  });
+  assert.equal(state.parseWindowsDesktopAppProcess(JSON.stringify([
+    { ProcessId: 1, Name: "Other.exe", ExecutablePath: "C:\\Other.exe", CommandLine: "C:\\Other.exe" },
+  ])), null);
+});
+
+test("Windows desktop app recovery uses the same complete debugging arguments", async () => {
+  const state = await import("../lib/injector-state.mjs");
+  assert.equal(typeof state.windowsDesktopAppLaunchArgs, "function");
+  assert.deepEqual(state.windowsDesktopAppLaunchArgs(9231), [
+    "--remote-debugging-port=9231",
+    "--remote-allow-origins=http://127.0.0.1:9231",
+    "--enable-features=LocalNetworkAccessForSubframeNavigationsWarningOnly",
+  ]);
+});

--- a/test/install-config.test.mjs
+++ b/test/install-config.test.mjs
@@ -5,7 +5,9 @@ import path from "node:path";
 import { spawnSync } from "node:child_process";
 import test from "node:test";
 
-test("installer dry-run renders portable user paths and XML-safe launch configuration", async () => {
+const macOnly = { skip: process.platform !== "darwin" };
+
+test("installer dry-run renders portable user paths and XML-safe launch configuration", macOnly, async () => {
   const testHome = await mkdtemp(path.join(os.tmpdir(), "codex-sidebar-home-"));
   const installDir = path.join(testHome, "Library", "Application Support", "Codex & Sidebar");
   try {
@@ -30,7 +32,7 @@ test("installer dry-run renders portable user paths and XML-safe launch configur
   }
 });
 
-test("installer activation writes a loadable user LaunchAgent without invoking launchctl in test mode", async () => {
+test("installer activation writes a loadable user LaunchAgent without invoking launchctl in test mode", macOnly, async () => {
   const testHome = await mkdtemp(path.join(os.tmpdir(), "codex-sidebar-activate-"));
   try {
     const launchAgentsDir = path.join(testHome, "Library", "LaunchAgents");
@@ -70,7 +72,7 @@ test("installer activation writes a loadable user LaunchAgent without invoking l
   }
 });
 
-test("installer explicitly kickstarts the registered LaunchAgent after bootstrap", async () => {
+test("installer explicitly kickstarts the registered LaunchAgent after bootstrap", macOnly, async () => {
   const testHome = await mkdtemp(path.join(os.tmpdir(), "codex-sidebar-kickstart-"));
   const fakeLaunchctl = path.join(testHome, "launchctl");
   const launchctlLog = path.join(testHome, "launchctl.log");

--- a/test/public-install.test.mjs
+++ b/test/public-install.test.mjs
@@ -6,8 +6,9 @@ import { spawnSync } from "node:child_process";
 import test from "node:test";
 
 const projectRoot = path.resolve(".");
+const macOnly = { skip: process.platform !== "darwin" };
 
-test("public installer copies a portable runtime and activates it under the current user", async () => {
+test("public installer copies a portable runtime and activates it under the current user", macOnly, async () => {
   const testHome = await mkdtemp(path.join(os.tmpdir(), "codex-sidebar-public-install-"));
   const installDir = path.join(testHome, "Library", "Application Support", "Codex Sidebar Enhancer");
   try {
@@ -40,7 +41,7 @@ test("public installer copies a portable runtime and activates it under the curr
   }
 });
 
-test("public uninstaller removes only the installed runtime, LaunchAgent, launcher, and logs", async () => {
+test("public uninstaller removes only the installed runtime, LaunchAgent, launcher, and logs", macOnly, async () => {
   const testHome = await mkdtemp(path.join(os.tmpdir(), "codex-sidebar-public-uninstall-"));
   const installDir = path.join(testHome, "Library", "Application Support", "Codex Sidebar Enhancer");
   const sharedEnv = {

--- a/test/windows-public-install.test.mjs
+++ b/test/windows-public-install.test.mjs
@@ -1,0 +1,61 @@
+import assert from "node:assert/strict";
+import { access, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { spawnSync } from "node:child_process";
+import test from "node:test";
+
+const windowsOnly = { skip: process.platform !== "win32" };
+const projectRoot = path.resolve(".");
+
+test("Windows public installer creates a user-local runtime and login shortcuts", windowsOnly, async () => {
+  const testRoot = await mkdtemp(path.join(os.tmpdir(), "codex-sidebar-windows-install-"));
+  const installDir = path.join(testRoot, "install");
+  const logsDir = path.join(testRoot, "logs");
+  const startupDir = path.join(testRoot, "startup");
+  const startMenuDir = path.join(testRoot, "start-menu");
+  const sentinel = path.join(testRoot, "keep.txt");
+  const env = {
+    ...process.env,
+    CODEX_SIDEBAR_SOURCE_DIR: projectRoot,
+    CODEX_SIDEBAR_INSTALL_DIR: installDir,
+    CODEX_SIDEBAR_LOGS_DIR: logsDir,
+    CODEX_SIDEBAR_STARTUP_DIR: startupDir,
+    CODEX_SIDEBAR_START_MENU_DIR: startMenuDir,
+    CODEX_SIDEBAR_NODE: process.execPath,
+    CODEX_SIDEBAR_SKIP_OPEN: "1",
+  };
+  try {
+    await writeFile(sentinel, "preserve");
+    const installed = spawnSync("powershell.exe", [
+      "-NoProfile",
+      "-ExecutionPolicy", "Bypass",
+      "-File", "install.ps1",
+    ], { cwd: projectRoot, encoding: "utf8", env });
+
+    assert.equal(installed.status, 0, installed.stderr);
+    assert.match(installed.stdout, /Codex Sidebar Enhancer installed for Windows/);
+    await access(path.join(installDir, "scripts", "injector.mjs"));
+    await access(path.join(installDir, "inject", "conversation-preview.user.js"));
+    const config = JSON.parse(await readFile(path.join(installDir, "windows", "config.json"), "utf8"));
+    assert.equal(path.resolve(config.nodePath), path.resolve(process.execPath));
+    assert.equal(config.port, 9231);
+    await access(path.join(startupDir, "Codex Sidebar Enhancer.lnk"));
+    await access(path.join(startMenuDir, "Codex Sidebar Enhancer.lnk"));
+
+    const removed = spawnSync("powershell.exe", [
+      "-NoProfile",
+      "-ExecutionPolicy", "Bypass",
+      "-File", "uninstall.ps1",
+    ], { cwd: projectRoot, encoding: "utf8", env });
+    assert.equal(removed.status, 0, removed.stderr);
+    assert.match(removed.stdout, /Codex Sidebar Enhancer uninstalled from Windows/);
+    await assert.rejects(access(installDir));
+    await assert.rejects(access(logsDir));
+    await assert.rejects(access(path.join(startupDir, "Codex Sidebar Enhancer.lnk")));
+    await assert.rejects(access(path.join(startMenuDir, "Codex Sidebar Enhancer.lnk")));
+    assert.equal(await readFile(sentinel, "utf8"), "preserve");
+  } finally {
+    await rm(testRoot, { recursive: true, force: true });
+  }
+});

--- a/uninstall.ps1
+++ b/uninstall.ps1
@@ -1,0 +1,46 @@
+[CmdletBinding()]
+param()
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+
+function Get-Setting([string]$Name, [string]$DefaultValue) {
+  $value = [Environment]::GetEnvironmentVariable($Name)
+  if ([string]::IsNullOrWhiteSpace($value)) { return $DefaultValue }
+  return $value
+}
+
+$localAppData = [Environment]::GetFolderPath("LocalApplicationData")
+$installDir = Get-Setting "CODEX_SIDEBAR_INSTALL_DIR" (Join-Path $localAppData "Codex Sidebar Enhancer")
+$logsDir = Get-Setting "CODEX_SIDEBAR_LOGS_DIR" (Join-Path $localAppData "CodexSidebarEnhancer\Logs")
+$startupDir = Get-Setting "CODEX_SIDEBAR_STARTUP_DIR" ([Environment]::GetFolderPath("Startup"))
+$startMenuDir = Get-Setting "CODEX_SIDEBAR_START_MENU_DIR" (Join-Path ([Environment]::GetFolderPath("Programs")) "Codex Sidebar Enhancer")
+$fullInstallDir = [IO.Path]::GetFullPath($installDir)
+$root = [IO.Path]::GetPathRoot($fullInstallDir)
+if ($fullInstallDir -eq $root -or $fullInstallDir -eq [IO.Path]::GetFullPath($localAppData)) {
+  throw "Unsafe install directory: $fullInstallDir"
+}
+
+$injectorPath = Join-Path $fullInstallDir "scripts\injector.mjs"
+try {
+  Get-CimInstance Win32_Process -Filter "Name = 'node.exe'" -ErrorAction SilentlyContinue |
+    Where-Object { $_.CommandLine -and $_.CommandLine.IndexOf($injectorPath, [StringComparison]::OrdinalIgnoreCase) -ge 0 } |
+    ForEach-Object { Stop-Process -Id $_.ProcessId -Force -ErrorAction SilentlyContinue }
+} catch {}
+
+$targets = @(
+  (Join-Path $startupDir "Codex Sidebar Enhancer.lnk"),
+  (Join-Path $startMenuDir "Codex Sidebar Enhancer.lnk"),
+  $fullInstallDir,
+  $logsDir
+)
+foreach ($target in $targets) {
+  if (Test-Path -LiteralPath $target) { Remove-Item -LiteralPath $target -Recurse -Force }
+}
+if (Test-Path -LiteralPath $startMenuDir -PathType Container) {
+  if (-not (Get-ChildItem -LiteralPath $startMenuDir -Force | Select-Object -First 1)) {
+    Remove-Item -LiteralPath $startMenuDir -Force
+  }
+}
+
+Write-Output "Codex Sidebar Enhancer uninstalled from Windows."

--- a/windows/launcher.ps1
+++ b/windows/launcher.ps1
@@ -1,0 +1,126 @@
+[CmdletBinding()]
+param([switch]$InjectorOnly)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+
+$configPath = Join-Path $PSScriptRoot "config.json"
+if (-not (Test-Path -LiteralPath $configPath)) { throw "Windows installation config is missing." }
+$config = Get-Content -LiteralPath $configPath -Raw | ConvertFrom-Json
+$installDir = [IO.Path]::GetFullPath((Join-Path $PSScriptRoot ".."))
+$injectorPath = Join-Path $installDir "scripts\injector.mjs"
+$nodePath = [string]$config.nodePath
+$port = [int]$config.port
+$logsDir = [string]$config.logsDir
+
+function Test-DebugPort {
+  $client = New-Object Net.Sockets.TcpClient
+  try {
+    $pending = $client.BeginConnect("127.0.0.1", $port, $null, $null)
+    if (-not $pending.AsyncWaitHandle.WaitOne(400)) { return $false }
+    $client.EndConnect($pending)
+    return $true
+  } catch {
+    return $false
+  } finally {
+    $client.Dispose()
+  }
+}
+
+function Get-MainDesktopProcess {
+  try {
+    return Get-CimInstance Win32_Process -ErrorAction Stop |
+      Where-Object {
+        $_.Name -in @("ChatGPT.exe", "Codex.exe") -and
+        $_.ExecutablePath -and
+        $_.CommandLine -notmatch "(?:^|\s)--type="
+      } |
+      Select-Object -First 1
+  } catch {
+    return $null
+  }
+}
+
+function Start-Injector {
+  $alreadyRunning = Get-CimInstance Win32_Process -Filter "Name = 'node.exe'" -ErrorAction SilentlyContinue |
+    Where-Object { $_.CommandLine -and $_.CommandLine.IndexOf($injectorPath, [StringComparison]::OrdinalIgnoreCase) -ge 0 } |
+    Select-Object -First 1
+  if ($alreadyRunning) { return }
+  New-Item -ItemType Directory -Path $logsDir -Force | Out-Null
+  Start-Process -FilePath $nodePath -ArgumentList @($injectorPath, "--port", [string]$port, "--watch") `
+    -WorkingDirectory $installDir -WindowStyle Hidden `
+    -RedirectStandardOutput (Join-Path $logsDir "injector.log") `
+    -RedirectStandardError (Join-Path $logsDir "injector.error.log")
+}
+
+function Find-DesktopExecutable {
+  $running = Get-MainDesktopProcess
+  if ($running) { return [string]$running.ExecutablePath }
+
+  $candidates = @(
+    (Join-Path $env:LOCALAPPDATA "Programs\ChatGPT\ChatGPT.exe"),
+    (Join-Path $env:LOCALAPPDATA "Programs\Codex\Codex.exe"),
+    (Join-Path $env:ProgramFiles "ChatGPT\ChatGPT.exe"),
+    (Join-Path $env:ProgramFiles "Codex\Codex.exe")
+  )
+  foreach ($candidate in $candidates) {
+    if (Test-Path -LiteralPath $candidate -PathType Leaf) { return $candidate }
+  }
+
+  try {
+    $packages = Get-AppxPackage -ErrorAction Stop |
+      Where-Object { $_.Name -match "OpenAI|ChatGPT|Codex" } |
+      Sort-Object -Property Version -Descending
+    foreach ($package in $packages) {
+      $manifest = Get-AppxPackageManifest -Package $package -ErrorAction SilentlyContinue
+      foreach ($application in @($manifest.Package.Applications.Application)) {
+        $relative = [string]$application.Executable
+        if ([string]::IsNullOrWhiteSpace($relative)) { continue }
+        $candidate = Join-Path $package.InstallLocation $relative
+        if ((Test-Path -LiteralPath $candidate -PathType Leaf) -and $candidate -match "(?:ChatGPT|Codex).*\.exe$") {
+          return $candidate
+        }
+      }
+    }
+  } catch {}
+  return $null
+}
+
+Start-Injector
+if ($InjectorOnly) { exit 0 }
+if (Test-DebugPort) { exit 0 }
+
+$runningApp = Get-MainDesktopProcess
+if ($runningApp) {
+  Add-Type -AssemblyName PresentationFramework
+  $answer = [Windows.MessageBox]::Show(
+    "Codex or ChatGPT must restart once to enable the sidebar enhancement.",
+    "Codex Sidebar Enhancer",
+    [Windows.MessageBoxButton]::YesNo,
+    [Windows.MessageBoxImage]::Information
+  )
+  if ($answer -ne [Windows.MessageBoxResult]::Yes) { exit 0 }
+  Stop-Process -Id $runningApp.ProcessId -Force
+  for ($attempt = 0; $attempt -lt 40; $attempt += 1) {
+    if (-not (Get-Process -Id $runningApp.ProcessId -ErrorAction SilentlyContinue)) { break }
+    Start-Sleep -Milliseconds 250
+  }
+}
+
+$appPath = Find-DesktopExecutable
+if (-not $appPath) {
+  Add-Type -AssemblyName PresentationFramework
+  [Windows.MessageBox]::Show(
+    "ChatGPT or Codex was not found. Install the Windows desktop app first.",
+    "Codex Sidebar Enhancer",
+    [Windows.MessageBoxButton]::OK,
+    [Windows.MessageBoxImage]::Error
+  ) | Out-Null
+  exit 1
+}
+
+Start-Process -FilePath $appPath -ArgumentList @(
+  "--remote-debugging-port=$port",
+  "--remote-allow-origins=http://127.0.0.1:$port",
+  "--enable-features=LocalNetworkAccessForSubframeNavigationsWarningOnly"
+)


### PR DESCRIPTION
## What changed

- add one-line PowerShell install and uninstall flows for Windows
- install a user-local verified Node 22 runtime when Node is unavailable
- create current-user Startup and Start Menu shortcuts without administrator privileges
- add Windows-aware Codex/ChatGPT process recovery and launch arguments
- fix the current Codex workspace mount regression affecting TV and Project Management
- document macOS and Windows installation paths
- run the suite on macOS and Windows in GitHub Actions

## Why

The project previously supported only macOS. The current Codex DOM also moved the main content frame behind the fixed header, causing both workspace shortcuts to reject a valid mount.

## Validation

- local Node suite: 63 passed, 0 failed, 1 Windows-only test skipped on macOS
- real Codex coordinate clicks: TV and Project Management both open in one click
- GitHub Actions run 31489804706 passed on macos-latest and windows-latest
- Windows runner exercised install, config, login shortcuts, uninstall, and unrelated-file preservation