### PR TITLE
Fix sidebar auto-recovery after Chromium updates

### DIFF
--- a/lib/desktop-runtime.mjs
+++ b/lib/desktop-runtime.mjs
@@ -1,4 +1,6 @@
 import { execFile, spawn } from "node:child_process";
+import os from "node:os";
+import path from "node:path";
 import { promisify } from "node:util";
 
 import {
@@ -19,6 +21,7 @@ const WINDOWS_PROCESS_QUERY = [
 
 export function createDesktopAppRuntime({
   platform = process.platform,
+  home = os.homedir(),
   execFileAsync = defaultExecFileAsync,
   spawnProcess = spawn,
 } = {}) {
@@ -54,7 +57,11 @@ export function createDesktopAppRuntime({
     launch(appPath, port) {
       const command = platform === "darwin" ? "/usr/bin/open" : appPath;
       const args = platform === "darwin"
-        ? desktopAppLaunchArgs(appPath, port)
+        ? desktopAppLaunchArgs(
+          appPath,
+          port,
+          path.posix.join(home, "Library", "Application Support", "Codex"),
+        )
         : windowsDesktopAppLaunchArgs(port);
       const child = spawnProcess(command, args, { detached: true, stdio: "ignore" });
       child.unref();

--- a/lib/injector-state.mjs
+++ b/lib/injector-state.mjs
@@ -31,15 +31,19 @@ export function parseDesktopAppProcess(processList) {
   return null;
 }
 
-export function desktopAppLaunchArgs(appPath, port) {
-  return [
+export function desktopAppLaunchArgs(appPath, port, userDataDir = null) {
+  const args = [
     "-na",
     appPath,
     "--args",
+  ];
+  if (userDataDir) args.push(`--user-data-dir=${userDataDir}`);
+  args.push(
     `--remote-debugging-port=${port}`,
     `--remote-allow-origins=http://127.0.0.1:${port}`,
     "--enable-features=LocalNetworkAccessForSubframeNavigationsWarningOnly",
-  ];
+  );
+  return args;
 }
 
 export function windowsDesktopAppLaunchArgs(port) {
@@ -72,8 +76,9 @@ export function parseWindowsDesktopAppProcess(processList) {
 }
 
 export class DesktopAppRecovery {
-  constructor({ quitRetryMs = 5_000 } = {}) {
+  constructor({ quitRetryMs = 5_000, launchRetryMs = 15_000 } = {}) {
     this.quitRetryMs = quitRetryMs;
+    this.launchRetryMs = launchRetryMs;
     this.pending = null;
   }
 
@@ -82,7 +87,9 @@ export class DesktopAppRecovery {
       this.pending = null;
       return null;
     }
-    if (this.pending?.phase === "launched") return null;
+    if (this.pending?.phase === "launched") {
+      if (!app || now - this.pending.launchedAt < this.launchRetryMs) return null;
+    }
     if (!app) {
       if (this.pending?.phase !== "quitting") return null;
       const appPath = this.pending.app.appPath;

--- a/test/desktop-runtime.test.mjs
+++ b/test/desktop-runtime.test.mjs
@@ -61,6 +61,7 @@ test("macOS runtime keeps the existing exact process, quit, and open behavior", 
   const child = { unref() {} };
   const runtime = createDesktopAppRuntime({
     platform: "darwin",
+    home: "/Users/example",
     execFileAsync: async (command, args) => {
       calls.push({ command, args });
       if (command === "/bin/ps") {
@@ -80,4 +81,13 @@ test("macOS runtime keeps the existing exact process, quit, and open behavior", 
   assert.equal(calls[0].command, "/bin/ps");
   assert.equal(calls[1].command, "/usr/bin/osascript");
   assert.equal(calls[2].command, "/usr/bin/open");
+  assert.deepEqual(calls[2].args, [
+    "-na",
+    "/Applications/ChatGPT.app",
+    "--args",
+    "--user-data-dir=/Users/example/Library/Application Support/Codex",
+    "--remote-debugging-port=9231",
+    "--remote-allow-origins=http://127.0.0.1:9231",
+    "--enable-features=LocalNetworkAccessForSubframeNavigationsWarningOnly",
+  ]);
 });

--- a/test/injector-state.test.mjs
+++ b/test/injector-state.test.mjs
@@ -87,17 +87,40 @@ test("desktop app recovery targets only the exact ChatGPT or Codex main process"
   assert.equal(state.parseDesktopAppProcess("42 /Applications/Other.app/Contents/MacOS/Other"), null);
 });
 
-test("desktop app recovery launches the app with the complete debugging arguments", async () => {
+test("desktop app recovery launches the app with the user profile and complete debugging arguments", async () => {
   const state = await import("../lib/injector-state.mjs");
   assert.equal(typeof state.desktopAppLaunchArgs, "function");
-  assert.deepEqual(state.desktopAppLaunchArgs("/Applications/ChatGPT.app", 9231), [
+  assert.deepEqual(state.desktopAppLaunchArgs(
+    "/Applications/ChatGPT.app",
+    9231,
+    "/Users/example/Library/Application Support/Codex",
+  ), [
     "-na",
     "/Applications/ChatGPT.app",
     "--args",
+    "--user-data-dir=/Users/example/Library/Application Support/Codex",
     "--remote-debugging-port=9231",
     "--remote-allow-origins=http://127.0.0.1:9231",
     "--enable-features=LocalNetworkAccessForSubframeNavigationsWarningOnly",
   ]);
+});
+
+test("desktop app recovery retries a launched app that never exposes the debugging target", async () => {
+  const state = await import("../lib/injector-state.mjs");
+  const recovery = new state.DesktopAppRecovery({ launchRetryMs: 10_000 });
+  const app = {
+    pid: 22323,
+    appPath: "/Applications/ChatGPT.app",
+    bundleId: "com.openai.codex",
+  };
+
+  recovery.pending = { phase: "launching", appPath: app.appPath };
+  recovery.markLaunched(1_000);
+  assert.equal(recovery.next({ targetAvailable: false, app, now: 9_000 }), null);
+  assert.deepEqual(recovery.next({ targetAvailable: false, app, now: 12_000 }), {
+    type: "quit",
+    app,
+  });
 });
 
 test("Windows desktop app recovery ignores Electron helpers and selects the main process", async () => {


### PR DESCRIPTION
## Summary
- launch macOS ChatGPT/Codex with the existing Codex user-data directory so Chromium 151 accepts the remote-debugging port
- retry recovery when a relaunched app never exposes the CDP target instead of remaining stuck forever
- add macOS launch-argument and failed-launch retry regression tests

## Verification
- `npm test`: 125 passed, 1 Windows-only test skipped
- installed v1.3.3 doctor: package, Taskboard, CDP and Asset Console all ready/running
- live Codex renderer: sidebar mounted with Project/Skills/Asset shortcuts, tabs, search and cards
- real CDP mouse input: list -> card -> list succeeded