### PR TITLE
fix: Windows 并发保存锁的短暂拒绝访问

### DIFF
--- a/lib/efficiency-store.mjs
+++ b/lib/efficiency-store.mjs
@@ -104,19 +104,31 @@ export class EfficiencyConflictError extends Error {
 
 // A process-owned mkdir lock covers the complete read/modify/atomic-rename cycle.
 // Never steal a live process's lock; a separate reaper lock prevents stale-lock ABA races.
-export async function withEfficiencyFileLock(filePath, callback, { timeoutMs = 5000 } = {}) {
+export async function withEfficiencyFileLock(filePath, callback, { timeoutMs = 5000, platform = process.platform, mkdirLock = mkdir } = {}) {
   await mkdir(path.dirname(filePath), { recursive: true, mode: 0o700 });
   const lockPath = `${filePath}.lock`;
   const token = randomUUID();
   const start = Date.now();
+  const waitForLock = async () => {
+    if (Date.now() - start > timeoutMs) { const error = new Error("Efficiency state is busy; retry later"); error.code = "EFFICIENCY_BUSY"; throw error; }
+    await delay(12 + Math.floor(Math.random() * 15));
+  };
   while (true) {
+    let acquired = false;
     try {
-      await mkdir(lockPath, { mode: 0o700 });
+      await mkdirLock(lockPath, { mode: 0o700 });
+      acquired = true;
       await (await open(path.join(lockPath, "owner.json"), "wx", 0o600)).close();
       const handle = await open(path.join(lockPath, "owner.json"), "w", 0o600);
       try { await handle.writeFile(JSON.stringify({ pid: process.pid, token, createdAt: Date.now() })); } finally { await handle.close(); }
       break;
     } catch (error) {
+      // NTFS may report a directory pending deletion as EPERM rather than
+      // EEXIST while another writer releases its lock. Only retry acquisition:
+      // never treat this as ownership, run the callback, or remove that lock.
+      if (!acquired && platform === "win32" && ["EPERM", "EACCES", "EBUSY"].includes(error.code)) {
+        await waitForLock(); continue;
+      }
       if (error.code !== "EEXIST") throw error;
       let owner;
       try { owner = JSON.parse(await readFile(path.join(lockPath, "owner.json"), "utf8")); } catch { /* An owner is still initializing; don't steal it. */ }
@@ -138,8 +150,7 @@ export async function withEfficiencyFileLock(filePath, callback, { timeoutMs = 5
         } catch (error) { if (!["ENOENT", "EEXIST"].includes(error.code)) throw error; }
         finally { if (acquired) await rm(reaper, { recursive: true, force: true }); }
       }
-      if (Date.now() - start > timeoutMs) { const error = new Error("Efficiency state is busy; retry later"); error.code = "EFFICIENCY_BUSY"; throw error; }
-      await delay(12 + Math.floor(Math.random() * 15));
+      await waitForLock();
     }
   }
   try { return await callback(); }

--- a/test/efficiency-store.test.mjs
+++ b/test/efficiency-store.test.mjs
@@ -94,6 +94,55 @@ test("a live process lock times out rather than being stolen", async (t) => {
   await writeFile(path.join(`${store.filePath}.lock`, "owner.json"), JSON.stringify({ pid: process.pid, token: "live", createdAt: 0 }));
   await assert.rejects(withEfficiencyFileLock(store.filePath, () => {}, { timeoutMs: 30 }), { code: "EFFICIENCY_BUSY" });
 });
+test("Windows transient lock acquisition errors retry before running exactly one writer", async (t) => {
+  const { store } = await fixture(t);
+  const errors = ["EPERM", "EACCES", "EBUSY"];
+  let attempts = 0;
+  let writes = 0;
+  const result = await withEfficiencyFileLock(store.filePath, async () => {
+    writes += 1;
+    assert.equal(attempts, 4);
+    assert.equal(JSON.parse(await readFile(path.join(`${store.filePath}.lock`, "owner.json"), "utf8")).pid, process.pid);
+    return "saved";
+  }, {
+    platform: "win32",
+    mkdirLock: async (...args) => {
+      assert.equal(writes, 0);
+      const code = errors[attempts++];
+      if (code) throw Object.assign(new Error("Directory pending deletion"), { code });
+      return mkdir(...args);
+    },
+  });
+  assert.equal(result, "saved");
+  assert.equal(writes, 1);
+  await assert.rejects(readFile(path.join(`${store.filePath}.lock`, "owner.json")), { code: "ENOENT" });
+});
+test("persistent Windows acquisition errors time out without touching another writer's lock", async (t) => {
+  const { store } = await fixture(t);
+  const ownerPath = path.join(`${store.filePath}.lock`, "owner.json");
+  const owner = JSON.stringify({ pid: process.pid, token: "other-writer", createdAt: 0 });
+  await mkdir(`${store.filePath}.lock`);
+  await writeFile(ownerPath, owner);
+  let writes = 0;
+  await assert.rejects(withEfficiencyFileLock(store.filePath, () => { writes += 1; }, {
+    timeoutMs: 30,
+    platform: "win32",
+    mkdirLock: async () => { throw Object.assign(new Error("Still busy"), { code: "EPERM" }); },
+  }), { code: "EFFICIENCY_BUSY" });
+  assert.equal(writes, 0);
+  assert.equal(await readFile(ownerPath, "utf8"), owner);
+});
+test("non-Windows permission failures and unrelated acquisition errors fail immediately", async (t) => {
+  const { store } = await fixture(t);
+  for (const [platform, code] of [["darwin", "EPERM"], ["win32", "ENOENT"]]) {
+    let attempts = 0;
+    await assert.rejects(withEfficiencyFileLock(store.filePath, () => assert.fail("Writer must not run"), {
+      platform,
+      mkdirLock: async () => { attempts += 1; throw Object.assign(new Error("Not retryable"), { code }); },
+    }), { code });
+    assert.equal(attempts, 1);
+  }
+});
 test("a dead process lock is recovered without dropping its already saved state", async (t) => {
   const { store } = await fixture(t);
   await store.setContext({ threadId: "a", expectedVersion: 0, context: { goal: "preserved" } });


### PR DESCRIPTION
## 修复范围
主分支发布后，Windows CI 在并发创建同名任务文件夹时出现 mkdir EPERM。旧锁目录正在删除时，NTFS 可能返回 EPERM 而不是 EEXIST。

- 仅对 Windows 获取锁阶段的 EPERM / EACCES / EBUSY 进行有时限重试。
- 未拿到锁不执行写入、不删除其他写入者的锁，原有超时与死进程锁回收机制不变。
- 其他平台权限错误、非瞬态错误继续立即报错。

## 验证
本地相关测试 30/30 通过，包含新增的短暂失败恢复、持续失败超时、不触碰其他写入者以及不可重试错误测试。合并前及合并后继续核验 macOS / Windows CI。

仅修改共享状态锁与测试，不包含私人 DramaTV 配置。